### PR TITLE
Dynamic sized strokes

### DIFF
--- a/fuzzpaint-core/src/repositories/points/io.rs
+++ b/fuzzpaint-core/src/repositories/points/io.rs
@@ -9,7 +9,7 @@ use super::*;
 struct DictMetadata {
     offset: u32,
     len: u32,
-    arch: PointArchetype,
+    arch: crate::stroke::Archetype,
 }
 
 // Collect all subsequent ones that will also fit
@@ -94,6 +94,7 @@ impl super::Points {
         ids: impl Iterator<Item = PointCollectionID>,
         writer: impl std::io::Write,
     ) -> Result<crate::io::id::FileLocalInterner<PointCollectionIDMarker>, WriteError> {
+        /*
         use crate::io::{
             riff::{encode::SizedBinaryChunkWriter, ChunkID},
             OrphanMode, Version,
@@ -216,7 +217,8 @@ impl super::Points {
         // Pad, if needed (shouldn't be)
         chunk.pad_slow()?;
 
-        Ok(file_ids)
+        Ok(file_ids)*/
+        todo!()
     }
     /// Intern all the data from the given `DICT ptls`, returning a map of the newly allocated
     /// IDs.
@@ -227,6 +229,7 @@ impl super::Points {
     where
         R: std::io::Read + crate::io::common::SoftSeek,
     {
+        /*
         use crate::io::{common::SoftSeek, id::ProcessLocalInterner, Version};
         use az::CheckedAs;
         use std::io::{Error as IOError, Read};
@@ -508,6 +511,7 @@ impl super::Points {
             }
         }
         // Report back the FileID->FuzzID mapping
-        Ok(file_ids)
+        Ok(file_ids)*/
+        todo!()
     }
 }

--- a/fuzzpaint-core/src/repositories/points/io.rs
+++ b/fuzzpaint-core/src/repositories/points/io.rs
@@ -7,7 +7,9 @@ use super::*;
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C, packed)]
 struct DictMetadata {
+    // Offset, in *bytes*
     offset: u32,
+    // Len, in *bytes*
     len: u32,
     arch: crate::stroke::Archetype,
 }
@@ -94,7 +96,6 @@ impl super::Points {
         ids: impl Iterator<Item = PointCollectionID>,
         writer: impl std::io::Write,
     ) -> Result<crate::io::id::FileLocalInterner<PointCollectionIDMarker>, WriteError> {
-        /*
         use crate::io::{
             riff::{encode::SizedBinaryChunkWriter, ChunkID},
             OrphanMode, Version,
@@ -201,6 +202,7 @@ impl super::Points {
 
                     let Some(slice) = slab.try_read(
                         entry.start,
+                        // len in points -> len in elems
                         entry.summary.len * entry.summary.archetype.elements(),
                     ) else {
                         // Implementation bug!
@@ -217,8 +219,7 @@ impl super::Points {
         // Pad, if needed (shouldn't be)
         chunk.pad_slow()?;
 
-        Ok(file_ids)*/
-        todo!()
+        Ok(file_ids)
     }
     /// Intern all the data from the given `DICT ptls`, returning a map of the newly allocated
     /// IDs.
@@ -229,7 +230,6 @@ impl super::Points {
     where
         R: std::io::Read + crate::io::common::SoftSeek,
     {
-        /*
         use crate::io::{common::SoftSeek, id::ProcessLocalInterner, Version};
         use az::CheckedAs;
         use std::io::{Error as IOError, Read};
@@ -258,14 +258,14 @@ impl super::Points {
         let reported_len = unstructured.data_len_unsanitized();
         // Make sure none surpass the end of the data chunk
         // AND make sure none surpass the limit of allocatable points, `SLAB_SIZE`
-        if !metas.iter().all(|m| {
-            m.1.len
-                .checked_add(m.1.offset)
+        if !metas.iter().all(|(_id, meta)| {
+            meta.len
+                .checked_add(meta.offset)
                 .is_some_and(|end| end <= reported_len as u32)
                 // Check small enough to even fit in a slab
-                && m.1.len as usize <= SLAB_ELEMENT_COUNT * std::mem::size_of::<f32>()
-                // Check is StrokePoint (relax this when other types available)
-                && m.1.len as usize % std::mem::size_of::<crate::stroke::Point>() == 0
+                && meta.len as usize <= SLAB_ELEMENT_COUNT * std::mem::size_of::<u32>()
+                // Check len matches reported archetype
+                && meta.len as usize % meta.arch.len_bytes() == 0
         }) {
             return Err(IOError::other(anyhow::anyhow!("point list data too long")));
         }
@@ -311,18 +311,18 @@ impl super::Points {
         // Todos: existing new slabs are not considered when searching for a slab to write in
         //   resulting in  a bunch of extra slabs being made
         let mut try_read_points = || -> Result<(), IOError> {
-            while let Some(first_meta) = metas.pop_front() {
+            while let Some((first_id, first_meta)) = metas.pop_front() {
                 // Find a block that fits it
                 let slabs = self.slabs.read();
                 let mut slab = {
                     let slab_info = slabs.iter().enumerate().find_map(|(idx, slab)| {
                         // Check if it *might* fit (can still fail)
                         // bytes -> elements
-                        if slab.hint_remaining() >= first_meta.1.len as usize / 4 {
+                        if slab.hint_remaining() >= first_meta.len as usize / 4 {
                             let lock = slab.lock();
                             // Check if it actually fits
                             // bytes -> elements
-                            if lock.remaining() >= first_meta.1.len as usize / 4 {
+                            if lock.remaining() >= first_meta.len as usize / 4 {
                                 Some((idx, lock))
                             } else {
                                 None
@@ -339,30 +339,30 @@ impl super::Points {
                 };
 
                 // Immutable - they're sorted, so the start point never needs to move.
-                let range_start_bytes = first_meta.1.offset;
-                let mut range_past_end_bytes = range_start_bytes + first_meta.1.len;
+                let range_start_bytes = first_meta.offset;
+                let mut range_past_end_bytes = range_start_bytes + first_meta.len;
 
                 // Keep track of free space
-                let mut remaining_elements = slab.remaining() - first_meta.1.len as usize / 4;
+                let mut remaining_elements = slab.remaining() - first_meta.len as usize / 4;
                 // First element we're writing into
                 let start_element = slab.position();
 
                 // We know metas only has a first slice because we never push!
-                let also_fit = take_while(metas.as_slices().0, |meta| {
+                let also_fit = take_while(metas.as_slices().0, |(_id, meta)| {
                     // Discontiguous!
                     // (dont need to check < start, they're sorted!)
-                    if meta.1.offset > range_past_end_bytes {
+                    if meta.offset > range_past_end_bytes {
                         return false;
                     }
                     // Unaligned!
-                    if (meta.1.offset - range_start_bytes) % 4 != 0 {
+                    if (meta.offset - range_start_bytes) % 4 != 0 {
                         return false;
                     }
                     // Fits?
-                    if meta.1.len as usize / 4 <= remaining_elements {
-                        remaining_elements -= meta.1.len as usize / 4;
+                    if meta.len as usize / 4 <= remaining_elements {
+                        remaining_elements -= meta.len as usize / 4;
                         // Push forward, if needed
-                        range_past_end_bytes = range_past_end_bytes.max(meta.1.offset + meta.1.len);
+                        range_past_end_bytes = range_past_end_bytes.max(meta.offset + meta.len);
                         true
                     } else {
                         false
@@ -394,9 +394,9 @@ impl super::Points {
                 slab.bump(count_elements).unwrap();
                 // Summarize (we could lower to read-only access on the slab but lifetimes are nightmare)
                 let summaries: Vec<CollectionSummary> = std::iter::once(&first_meta)
-                    .chain(also_fit.iter())
-                    .map(|(_, meta)| {
-                        let last_point = if meta.len == 0 {
+                    .chain(also_fit.iter().map(|(_, meta)| meta))
+                    .map(|meta| {
+                        let stroke = if meta.len == 0 {
                             None
                         } else {
                             let (immutable, _) = slab.parts_mut();
@@ -405,30 +405,13 @@ impl super::Points {
                                 start_element + (meta.offset - range_start_bytes) as usize / 4;
                             // Find where the past-the-end point in the slab
                             let past_the_end = start_idx + meta.len as usize / 4;
-                            // Step back one point
-                            let last_point_start = past_the_end - meta.arch.elements();
                             // Make sure we didn't step back past the start
-                            if last_point_start >= start_idx {
-                                // Try to read elements+cast to point
-                                let opt_last_point = immutable
-                                    .get(last_point_start..last_point_start + meta.arch.elements())
-                                    .and_then(|slice| {
-                                        bytemuck::try_cast_slice::<_, crate::stroke::Point>(slice)
-                                            .ok()
-                                    })
-                                    .and_then(|slice| slice.first());
-                                opt_last_point
-                            } else {
-                                None
-                            }
+                            immutable
+                                .get(start_idx..past_the_end)
+                                .and_then(|slice| StrokeSlice::new(slice, meta.arch))
                         };
-                        CollectionSummary {
-                            archetype: meta.arch,
-                            len: meta.len as usize / std::mem::size_of::<crate::stroke::Point>(),
-                            // Option into Optional panics on none? silly dubious
-                            // Some if available and non-nan, None otherwise.
-                            arc_length: last_point.map(|l| l.dist),
-                        }
+
+                        super::summarize(stroke.unwrap_or(StrokeSlice::empty(meta.arch)))
                     })
                     .collect();
 
@@ -443,7 +426,7 @@ impl super::Points {
                 };
 
                 // Create alloc infos
-                std::iter::once(&first_meta)
+                std::iter::once(&(first_id, first_meta))
                     .chain(also_fit.iter())
                     .zip(summaries.into_iter())
                     .for_each(|((id, meta), summary)| {
@@ -511,7 +494,6 @@ impl super::Points {
             }
         }
         // Report back the FileID->FuzzID mapping
-        Ok(file_ids)*/
-        todo!()
+        Ok(file_ids)
     }
 }

--- a/fuzzpaint-core/src/stroke/archetype.rs
+++ b/fuzzpaint-core/src/stroke/archetype.rs
@@ -48,7 +48,7 @@ impl Archetype {
     }
     #[must_use]
     pub const fn len_bytes(self) -> usize {
-        self.elements() * std::mem::size_of::<f32>()
+        self.elements() * std::mem::size_of::<u32>()
     }
     /// Fetch the offset of the given property. None if the property isn't included.
     /// *`other` should have just one bit set.* Otherwise, the returned value is meaningless.

--- a/fuzzpaint-core/src/stroke/archetype.rs
+++ b/fuzzpaint-core/src/stroke/archetype.rs
@@ -5,12 +5,9 @@ bitflags::bitflags! {
     ///
     /// Note that position nor arc_length are required fields. Arc_length is derived data,
     /// and position may be ignored for strokes which trace a predefined path.
-    ///
-    /// Selected (loosely) from 2D-drawing-relavent packets defined in the windows ink API:
-    /// https://learn.microsoft.com/en-us/windows/win32/tablet/packetpropertyguids-constants
     #[rustfmt::skip]
     #[repr(transparent)]
-    pub struct PointArchetype : u8 {
+    pub struct Archetype : u8 {
         /// The point stream reports an (X: f32, Y: f32) position.
         const POSITION =   0b0000_0001;
         /// The point stream reports an f32 timestamp, in seconds from an arbitrary start moment.
@@ -38,7 +35,7 @@ bitflags::bitflags! {
         const WHEEL =      0b1000_0000;
     }
 }
-impl PointArchetype {
+impl Archetype {
     /// How many elements (f32) does a point of this archetype occupy?
     #[must_use]
     pub const fn elements(self) -> usize {
@@ -52,5 +49,21 @@ impl PointArchetype {
     #[must_use]
     pub const fn len_bytes(self) -> usize {
         self.elements() * std::mem::size_of::<f32>()
+    }
+    /// Fetch the offset of the given property. None if the property isn't included.
+    /// *`other` should have just one bit set.* Otherwise, the returned value is meaningless.
+    #[must_use]
+    pub const fn offset_of(self, other: Self) -> Option<usize> {
+        if self.intersects(other) {
+            // Bitmask of every element ordered *before* the requested element
+            //   1000
+            //    - 1
+            // = 0111
+            let before_mask = Self::from_bits_retain(other.bits() - 1);
+            // Count how many elements *before* the given element are set.
+            Some(self.intersection(before_mask).elements())
+        } else {
+            None
+        }
     }
 }

--- a/fuzzpaint-core/src/stroke/archetype.rs
+++ b/fuzzpaint-core/src/stroke/archetype.rs
@@ -67,3 +67,49 @@ impl Archetype {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::Archetype;
+    #[test]
+    /// Tests [`Archetype::offset_of`] and indirectly [`Archetype::elements`]
+    fn all_offsets() {
+        let test = Archetype::all();
+
+        // flag, offset
+        let expected = [
+            (Archetype::POSITION, Some(0)),
+            (Archetype::TIME, Some(2)),
+            (Archetype::ARC_LENGTH, Some(3)),
+            (Archetype::PRESSURE, Some(4)),
+            (Archetype::TILT, Some(5)),
+            (Archetype::DISTANCE, Some(7)),
+            (Archetype::ROLL, Some(8)),
+            (Archetype::WHEEL, Some(9)),
+        ];
+
+        for (flag, offs) in expected {
+            assert_eq!(test.offset_of(flag), offs);
+        }
+    }
+    #[test]
+    fn offsets_gap() {
+        // Some selections with gaps between
+        let test = Archetype::POSITION | Archetype::TILT | Archetype::WHEEL;
+        // flag, offset
+        let expected = [
+            (Archetype::POSITION, Some(0)),
+            (Archetype::TIME, None),
+            (Archetype::ARC_LENGTH, None),
+            (Archetype::PRESSURE, None),
+            (Archetype::TILT, Some(2)),
+            (Archetype::DISTANCE, None),
+            (Archetype::ROLL, None),
+            (Archetype::WHEEL, Some(4)),
+        ];
+
+        for (flag, offs) in expected {
+            assert_eq!(test.offset_of(flag), offs);
+        }
+    }
+}

--- a/fuzzpaint-core/src/stroke/mod.rs
+++ b/fuzzpaint-core/src/stroke/mod.rs
@@ -1,24 +1,252 @@
-#[derive(bytemuck::Pod, bytemuck::Zeroable, Clone, Copy)]
-#[repr(C)]
-pub struct Point {
-    pub pos: [f32; 2],
-    pub pressure: f32,
-    /// Arc length of stroke from beginning to this point
-    pub dist: f32,
+pub mod archetype;
+pub use archetype::Archetype;
+
+//U32::MAX us == 71 minutes. If someone draws one continuous stroke for that long, other problems would certainly arise. D:
+#[derive(bytemuck::Pod, bytemuck::Zeroable, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[repr(transparent)]
+pub struct Microseconds(pub u32);
+
+/// A single dynamically structured point.
+#[derive(Clone, Copy)]
+pub struct BorrowedPoint<'a> {
+    /// Invariant: `data.len == archetype.elements`
+    elements: &'a [u32],
+    archetype: Archetype,
 }
-impl Point {
-    #[must_use]
-    pub const fn archetype() -> crate::repositories::points::PointArchetype {
-        use crate::repositories::points::PointArchetype;
-        // | isn't const except for on the bits type! x3
-        // This is infallible but unwrap also isn't const.
-        match PointArchetype::from_bits(
-            PointArchetype::POSITION.bits()
-                | PointArchetype::PRESSURE.bits()
-                | PointArchetype::ARC_LENGTH.bits(),
-        ) {
-            Some(s) => s,
-            None => unreachable!(),
+impl<'a> BorrowedPoint<'a> {
+    pub fn empty() -> Self {
+        BorrowedPoint {
+            elements: &[],
+            archetype: Archetype::empty(),
         }
+    }
+    /// Borrow a slice as a point. Returns `None` if the length of the data is not `archetype.elements()`
+    ///
+    /// The elements in data will be interpreted as a series of packed elements. For each flag of `archetype` in order, sequential `u32`
+    /// values will be interpreted as the relevant type as documented in [`Archetype`].
+    /// This is a safe function as all such `transmutes` from any `u32` to any of the relevant types is sound.
+    #[must_use]
+    pub fn new(elements: &'a [u32], archetype: Archetype) -> Option<Self> {
+        // Check that lengths make sense
+        if elements.len() == archetype.elements() {
+            Some(Self {
+                elements,
+                archetype,
+            })
+        } else {
+            None
+        }
+    }
+    pub fn position(&self) -> Option<[f32; 2]> {
+        self.archetype.offset_of(Archetype::POSITION).map(|idx| {
+            let data: [u32; 2] = self.elements[idx..idx + 2].try_into().unwrap();
+            bytemuck::cast(data)
+        })
+    }
+    pub fn time(&self) -> Option<Microseconds> {
+        self.archetype.offset_of(Archetype::TIME).map(|idx| {
+            let data = self.elements[idx];
+            bytemuck::cast(data)
+        })
+    }
+    pub fn arc_length(&self) -> Option<f32> {
+        self.archetype.offset_of(Archetype::ARC_LENGTH).map(|idx| {
+            let data = self.elements[idx];
+            bytemuck::cast(data)
+        })
+    }
+    pub fn pressure(&self) -> Option<f32> {
+        self.archetype.offset_of(Archetype::PRESSURE).map(|idx| {
+            let data = self.elements[idx];
+            bytemuck::cast(data)
+        })
+    }
+    pub fn tilt(&self) -> Option<[f32; 2]> {
+        self.archetype.offset_of(Archetype::TILT).map(|idx| {
+            let data: [u32; 2] = self.elements[idx..idx + 2].try_into().unwrap();
+            bytemuck::cast(data)
+        })
+    }
+    pub fn distance(&self) -> Option<f32> {
+        self.archetype.offset_of(Archetype::DISTANCE).map(|idx| {
+            let data = self.elements[idx];
+            bytemuck::cast(data)
+        })
+    }
+    pub fn roll(&self) -> Option<f32> {
+        self.archetype.offset_of(Archetype::ROLL).map(|idx| {
+            let data = self.elements[idx];
+            bytemuck::cast(data)
+        })
+    }
+    pub fn wheel(&self) -> Option<f32> {
+        self.archetype.offset_of(Archetype::WHEEL).map(|idx| {
+            let data = self.elements[idx];
+            bytemuck::cast(data)
+        })
+    }
+}
+impl std::fmt::Debug for BorrowedPoint<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("BorrowedPoint");
+        if let Some(position) = self.position() {
+            d.field("position", &position);
+        }
+        if let Some(time) = self.time() {
+            d.field("time", &time);
+        }
+        if let Some(arc_length) = self.arc_length() {
+            d.field("arc_length", &arc_length);
+        }
+        if let Some(pressure) = self.pressure() {
+            d.field("pressure", &pressure);
+        }
+        if let Some(tilt) = self.tilt() {
+            d.field("tilt", &tilt);
+        }
+        if let Some(distance) = self.distance() {
+            d.field("distance", &distance);
+        }
+        if let Some(roll) = self.roll() {
+            d.field("roll", &roll);
+        }
+        if let Some(wheel) = self.wheel() {
+            d.field("wheel", &wheel);
+        }
+        d.finish()
+    }
+}
+
+/// A dynamic layout structure containing many packed points based on an archetype.
+#[derive(Clone, Copy)]
+pub struct StrokeSlice<'a> {
+    elements: &'a [u32],
+    archetype: Archetype,
+    /// Number of points in this stroke.
+    /// Invariant: `self.len * self.archetype.elements() == self.elements.len()`
+    len: usize,
+}
+impl<'a> StrokeSlice<'a> {
+    /// Create an empty borrow of the given archetype.
+    #[must_use]
+    pub fn empty(archetype: Archetype) -> Self {
+        Self {
+            archetype,
+            elements: &[],
+            len: 0,
+        }
+    }
+    /// Borrow a slice as a stroke. Returns `None` if the length of the data is not divisible by `archetype.elements()`
+    ///
+    /// The elements in data will be interpreted as a series of packed points. For each flag of `archetype` in order, sequential `u32`
+    /// values will be interpreted as the relevant type as documented in [`Archetype`].
+    /// This is a safe function as all such `transmutes` from any `u32` to any of the relevant types is sound.
+    #[must_use]
+    pub fn new(elements: &'a [u32], archetype: Archetype) -> Option<Self> {
+        // Special cases: Avoid div by zero
+        if elements.is_empty() {
+            return Some(Self::empty(archetype));
+        }
+        if archetype.is_empty() {
+            // Arch is empty but data is not, that makes no sense!
+            return None;
+        }
+
+        // Ensure data len makes sense given the archetype:
+        if elements.len() % archetype.elements() != 0 {
+            return None;
+        }
+
+        let len = elements.len() / archetype.elements();
+        Some(Self {
+            elements,
+            archetype,
+            len,
+        })
+    }
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    /// Get the number of *points* in this stroke.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+    #[must_use]
+    pub fn archetype(&self) -> Archetype {
+        self.archetype
+    }
+    /// Get the full data as bytes.
+    #[must_use]
+    pub fn bytes(&self) -> &'a [u8] {
+        bytemuck::cast_slice(self.elements)
+    }
+    /// Get the full data interpreted as `u32`
+    #[must_use]
+    pub fn elements(&self) -> &'a [u32] {
+        self.elements
+    }
+    /// Take a sub-stroke of this stroke. Indices are in units of *points*.
+    #[must_use = "returns a new instance without modifying `self`"]
+    pub fn slice<R: std::ops::RangeBounds<usize>>(self, range: R) -> Option<Self> {
+        let start = match range.start_bound() {
+            std::ops::Bound::Unbounded => 0,
+            std::ops::Bound::Excluded(&x) => x.checked_add(1)?,
+            std::ops::Bound::Included(&x) => x,
+        };
+        let end = match range.end_bound() {
+            std::ops::Bound::Unbounded => self.len,
+            std::ops::Bound::Excluded(&x) => x,
+            std::ops::Bound::Included(&x) => x.checked_add(1)?,
+        };
+
+        // Mimic behavior of `[T]::get`
+        // empty range is OK, starting one-past-end is OK.
+        if start > end {
+            return None;
+        }
+        if start > self.len {
+            return None;
+        }
+
+        let sliced_len = end - start;
+        let elems = self.archetype.elements();
+
+        Some(Self {
+            // Shoullldd always be Some
+            elements: self.elements.get(start * elems..end * elems)?,
+            archetype: self.archetype,
+            len: sliced_len,
+        })
+    }
+    /// Fetch the first point of this stroke slice. `None` if empty.
+    pub fn first(&self) -> Option<BorrowedPoint<'a>> {
+        self.get(0)
+    }
+    /// Fetch the last point of this stroke slice. `None` if empty.
+    pub fn last(&self) -> Option<BorrowedPoint<'a>> {
+        self.get(self.len().checked_sub(1)?)
+    }
+    /// Fetch a point from the stroke slice. `None` if out-of-bounds.
+    pub fn get(&self, idx: usize) -> Option<BorrowedPoint<'a>> {
+        if idx >= self.len() {
+            return None;
+        }
+        let elements = self.slice(idx..=idx).unwrap().elements();
+        Some(BorrowedPoint::new(elements, self.archetype()).unwrap())
+    }
+}
+impl std::fmt::Debug for StrokeSlice<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("StrokeSlice");
+        d.field(
+            "points",
+            // Grr.. `field_with` would fix this, but unstable. eh.
+            &(0..self.len())
+                .map(|i| self.get(i).unwrap())
+                .collect::<Vec<_>>(),
+        );
+        d.finish()
     }
 }

--- a/fuzzpaint-core/src/stroke/mod.rs
+++ b/fuzzpaint-core/src/stroke/mod.rs
@@ -129,7 +129,7 @@ pub struct StrokeSlice<'a> {
 impl<'a> StrokeSlice<'a> {
     /// Create an empty borrow of the given archetype.
     #[must_use]
-    pub fn empty(archetype: Archetype) -> Self {
+    pub const fn empty(archetype: Archetype) -> Self {
         Self {
             archetype,
             elements: &[],
@@ -240,6 +240,8 @@ impl<'a> StrokeSlice<'a> {
 impl std::fmt::Debug for StrokeSlice<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut d = f.debug_struct("StrokeSlice");
+        // Redundant with values of `points`, HOWEVER points could be empty!
+        d.field("archetype", &self.archetype);
         d.field(
             "points",
             // Grr.. `field_with` would fix this, but unstable. eh.

--- a/fuzzpaint/src/main.rs
+++ b/fuzzpaint/src/main.rs
@@ -61,24 +61,6 @@ impl AdHocGlobals {
     }
 }
 
-pub struct Stroke {
-    brush: fuzzpaint_core::state::StrokeBrushSettings,
-    points: Vec<fuzzpaint_core::stroke::Point>,
-}
-impl Stroke {
-    fn make_immutable(&self) -> fuzzpaint_core::state::stroke_collection::ImmutableStroke {
-        let points = crate::global::points();
-        let point_collection = points
-            .insert(&self.points)
-            .expect("Failed to upload stroke data");
-        fuzzpaint_core::state::stroke_collection::ImmutableStroke {
-            id: FuzzID::default(),
-            brush: self.brush,
-            point_collection,
-        }
-    }
-}
-
 async fn stylus_event_collector(
     mut event_stream: tokio::sync::broadcast::Receiver<stylus_events::StylusEventFrame>,
     ui_requests: crossbeam::channel::Receiver<ui::requests::UiRequest>,

--- a/fuzzpaint/src/pen_tools/brush.rs
+++ b/fuzzpaint/src/pen_tools/brush.rs
@@ -1,7 +1,311 @@
+use fuzzpaint_core::stroke::{Archetype, Microseconds, StrokeSlice};
+
+#[derive(Clone, Copy)]
+pub struct InputPoint {
+    pub position: [f32; 2],
+    /// Time since start of stroke.
+    pub time: Option<Microseconds>,
+    /// Pressure, `[0,1]`
+    pub pressure: Option<f32>,
+    /// X,Y Tilt
+    pub tilt: Option<[f32; 2]>,
+    /// Distance from the surface, `[0,1]`
+    pub distance: Option<f32>,
+    /// Rotation of the pen, `[0, TAU]`
+    pub roll: Option<f32>,
+    /// "Wheel" position, unitless + unbounded.
+    pub wheel: Option<f32>,
+}
+impl InputPoint {
+    pub const DEFAULT_TIME: Microseconds = Microseconds(0);
+    pub const DEFAULT_PRESSURE: f32 = 1.0;
+    pub const DEFAULT_TILT: [f32; 2] = [0.0; 2];
+    pub const DEFAULT_DISTANCE: f32 = 0.0;
+    pub const DEFAULT_ROLL: f32 = 0.0;
+    pub const DEFAULT_WHEEL: f32 = 0.0;
+    #[must_use]
+    pub fn archetype(&self) -> Archetype {
+        const EMPTY: Archetype = Archetype::empty();
+
+        Archetype::POSITION
+            | self.time.map_or(EMPTY, |_| Archetype::TIME)
+            | self.pressure.map_or(EMPTY, |_| Archetype::PRESSURE)
+            | self.tilt.map_or(EMPTY, |_| Archetype::TILT)
+            | self.distance.map_or(EMPTY, |_| Archetype::DISTANCE)
+            | self.roll.map_or(EMPTY, |_| Archetype::ROLL)
+            | self.wheel.map_or(EMPTY, |_| Archetype::WHEEL)
+    }
+    /// Remove all default values, replacing them with `None`.
+    /// Eg, roll of `Some(0)` becomes `None`.
+    ///
+    /// Useful because some tablet APIs lie about actual capabilities and simply report `Some(0)` always :P
+    #[must_use = "returns a new instance without modifying `self`"]
+    pub fn without_defaults(self) -> Self {
+        let Self {
+            position,
+            time,
+            pressure,
+            tilt,
+            distance,
+            roll,
+            wheel,
+        } = self;
+
+        Self {
+            position, // No default.
+            time: time.filter(|&v| v != Self::DEFAULT_TIME),
+            pressure: pressure.filter(|&v| v != Self::DEFAULT_PRESSURE),
+            tilt: tilt.filter(|&v| v != Self::DEFAULT_TILT),
+            distance: distance.filter(|&v| v != Self::DEFAULT_DISTANCE),
+            roll: roll.filter(|&v| v != Self::DEFAULT_ROLL),
+            wheel: wheel.filter(|&v| v != Self::DEFAULT_WHEEL),
+        }
+    }
+    /// Add defaults to make up for any missing fields to match the given archetype.
+    /// # Panics
+    /// If `archetype` contains `ARC_LENGTH` which is unrepresentable by `Self`.
+    #[must_use = "returns a new instance without modifying `self`"]
+    pub fn or_defaults(self, archetype: Archetype) -> Self {
+        let Self {
+            position,
+            time,
+            pressure,
+            tilt,
+            distance,
+            roll,
+            wheel,
+        } = self;
+
+        Self {
+            position,
+            time: if archetype.intersects(Archetype::TIME) {
+                Some(time.unwrap_or(Self::DEFAULT_TIME))
+            } else {
+                time
+            },
+            pressure: if archetype.intersects(Archetype::PRESSURE) {
+                Some(pressure.unwrap_or(Self::DEFAULT_PRESSURE))
+            } else {
+                pressure
+            },
+            tilt: if archetype.intersects(Archetype::TILT) {
+                Some(tilt.unwrap_or(Self::DEFAULT_TILT))
+            } else {
+                tilt
+            },
+            distance: if archetype.intersects(Archetype::DISTANCE) {
+                Some(distance.unwrap_or(Self::DEFAULT_DISTANCE))
+            } else {
+                distance
+            },
+            roll: if archetype.intersects(Archetype::ROLL) {
+                Some(roll.unwrap_or(Self::DEFAULT_ROLL))
+            } else {
+                roll
+            },
+            wheel: if archetype.intersects(Archetype::WHEEL) {
+                Some(wheel.unwrap_or(Self::DEFAULT_WHEEL))
+            } else {
+                wheel
+            },
+        }
+    }
+}
+impl Default for StrokeBuilder {
+    fn default() -> Self {
+        Self {
+            position: vec![],
+            time: vec![],
+            pressure: vec![],
+            tilt: vec![],
+            distance: vec![],
+            roll: vec![],
+            wheel: vec![],
+            current_archetype: Archetype::POSITION,
+            packed_elements: vec![],
+        }
+    }
+}
+/// Structure-of-arrays form of a list of [`InputPoint`]s which can then be packed into a [`StrokeSlice`].
+/// This allows for dynamic packing structure across strokes.
+pub struct StrokeBuilder {
+    /// Currently required! As such, this indicates len.
+    position: Vec<[f32; 2]>,
+    time: Vec<Microseconds>,
+    pressure: Vec<f32>,
+    tilt: Vec<[f32; 2]>,
+    distance: Vec<f32>,
+    roll: Vec<f32>,
+    wheel: Vec<f32>,
+    /// Which of the vecs are active?
+    current_archetype: Archetype,
+    /// On finish, write elements out to here and borrow them as a StrokeSlice.
+    packed_elements: Vec<u32>,
+}
+impl StrokeBuilder {
+    pub fn clear(&mut self) {
+        self.position.clear();
+        self.time.clear();
+        self.pressure.clear();
+        self.tilt.clear();
+        self.distance.clear();
+        self.roll.clear();
+        self.wheel.clear();
+        // Position is required.
+        self.current_archetype = Archetype::POSITION;
+    }
+    pub fn is_empty(&self) -> bool {
+        self.position.is_empty()
+    }
+    pub fn len(&self) -> usize {
+        self.position.len()
+    }
+    pub fn push(&mut self, point: InputPoint) {
+        // Delete empty data
+        let stripped = point.without_defaults();
+        // See if any elements are new!
+        let new_elements = stripped.archetype().difference(self.current_archetype);
+
+        // Add missing elements in with defaults...
+        if new_elements.intersects(Archetype::TIME) {
+            self.time.resize(self.len(), InputPoint::DEFAULT_TIME);
+        }
+        if new_elements.intersects(Archetype::PRESSURE) {
+            self.pressure
+                .resize(self.len(), InputPoint::DEFAULT_PRESSURE);
+        }
+        if new_elements.intersects(Archetype::TILT) {
+            self.tilt.resize(self.len(), InputPoint::DEFAULT_TILT);
+        }
+        if new_elements.intersects(Archetype::DISTANCE) {
+            self.pressure
+                .resize(self.len(), InputPoint::DEFAULT_DISTANCE);
+        }
+        if new_elements.intersects(Archetype::ROLL) {
+            self.pressure.resize(self.len(), InputPoint::DEFAULT_ROLL);
+        }
+        if new_elements.intersects(Archetype::WHEEL) {
+            self.pressure.resize(self.len(), InputPoint::DEFAULT_WHEEL);
+        }
+        self.current_archetype |= stripped.archetype();
+
+        // Fill in the new point to match self
+        let InputPoint {
+            position,
+            time,
+            pressure,
+            tilt,
+            distance,
+            roll,
+            wheel,
+        } = stripped.or_defaults(self.current_archetype);
+
+        // Push it all!
+        self.position.push(position);
+        if let Some(v) = time {
+            self.time.push(v);
+        }
+        if let Some(v) = pressure {
+            self.pressure.push(v);
+        }
+        if let Some(v) = tilt {
+            self.tilt.push(v);
+        }
+        if let Some(v) = distance {
+            self.distance.push(v);
+        }
+        if let Some(v) = roll {
+            self.roll.push(v);
+        }
+        if let Some(v) = wheel {
+            self.wheel.push(v);
+        }
+    }
+    /// Pack the contents and borrow them as a stroke.
+    pub fn consume(&mut self) -> StrokeSlice {
+        self.packed_elements.clear();
+
+        let archetype = self.current_archetype | Archetype::ARC_LENGTH;
+        let point_size = archetype.elements();
+        let packed_len = point_size * self.len();
+        self.packed_elements.resize(packed_len, 0);
+
+        // Write out positions + calc arclens as we go!
+        // (Positions + Arclen are required rn)
+        {
+            let mut arclen = 0.0f32;
+            let mut last_position = None;
+            for (idx, &position) in self.position.iter().enumerate() {
+                let base = idx * point_size;
+                let position_offs = archetype.offset_of(Archetype::POSITION).unwrap();
+                self.packed_elements[base + position_offs] = bytemuck::cast(position[0]);
+                self.packed_elements[base + position_offs + 1] = bytemuck::cast(position[1]);
+
+                // Calc and write arc len
+                let arclen_offs = archetype.offset_of(Archetype::ARC_LENGTH).unwrap();
+                if let Some(last_position) = last_position.replace(position) {
+                    let delta = [
+                        last_position[0] - position[0],
+                        last_position[1] - position[1],
+                    ];
+                    arclen += (delta[0] * delta[0] + delta[1] * delta[1]).sqrt();
+                }
+                self.packed_elements[base + arclen_offs] = bytemuck::cast(arclen);
+            }
+        }
+        if archetype.intersects(Archetype::TIME) {
+            for (idx, &v) in self.time.iter().enumerate() {
+                let base = idx * point_size;
+                let offs = archetype.offset_of(Archetype::TIME).unwrap();
+                self.packed_elements[base + offs] = bytemuck::cast(v);
+            }
+        }
+        if archetype.intersects(Archetype::PRESSURE) {
+            for (idx, &v) in self.pressure.iter().enumerate() {
+                let base = idx * point_size;
+                let offs = archetype.offset_of(Archetype::PRESSURE).unwrap();
+                self.packed_elements[base + offs] = bytemuck::cast(v);
+            }
+        }
+        if archetype.intersects(Archetype::TILT) {
+            for (idx, &v) in self.tilt.iter().enumerate() {
+                let base = idx * point_size;
+                let offs = archetype.offset_of(Archetype::TILT).unwrap();
+                self.packed_elements[base + offs] = bytemuck::cast(v[0]);
+                self.packed_elements[base + offs + 1] = bytemuck::cast(v[1]);
+            }
+        }
+        if archetype.intersects(Archetype::DISTANCE) {
+            for (idx, &v) in self.distance.iter().enumerate() {
+                let base = idx * point_size;
+                let offs = archetype.offset_of(Archetype::DISTANCE).unwrap();
+                self.packed_elements[base + offs] = bytemuck::cast(v);
+            }
+        }
+        if archetype.intersects(Archetype::ROLL) {
+            for (idx, &v) in self.roll.iter().enumerate() {
+                let base = idx * point_size;
+                let offs = archetype.offset_of(Archetype::ROLL).unwrap();
+                self.packed_elements[base + offs] = bytemuck::cast(v);
+            }
+        }
+        if archetype.intersects(Archetype::WHEEL) {
+            for (idx, &v) in self.wheel.iter().enumerate() {
+                let base = idx * point_size;
+                let offs = archetype.offset_of(Archetype::WHEEL).unwrap();
+                self.packed_elements[base + offs] = bytemuck::cast(v);
+            }
+        }
+
+        self.clear();
+        StrokeSlice::new(&self.packed_elements, archetype).unwrap()
+    }
+}
+
 // Common core between eraser and brush
 fn brush(
     is_eraser: bool,
-    in_progress_stroke: &mut Option<crate::Stroke>,
+    builder: &mut StrokeBuilder,
 
     view: &super::ViewInfo,
     stylus_input: crate::stylus_events::StylusEventFrame,
@@ -16,7 +320,7 @@ fn brush(
     }) = crate::AdHocGlobals::read_clone()
     else {
         // Clear and bail.
-        *in_progress_stroke = None;
+        builder.clear();
         return;
     };
     let Some(view_transform) = view.calculate_transform() else {
@@ -24,28 +328,22 @@ fn brush(
     };
     for event in stylus_input.iter() {
         if event.pressed {
-            // Get stroke-in-progress or start anew.
-            let this_stroke = in_progress_stroke.get_or_insert_with(|| crate::Stroke {
-                brush: fuzzpaint_core::state::StrokeBrushSettings { is_eraser, ..brush },
-                points: Vec::new(),
-            });
             let Ok(pos) = view_transform.unproject(cgmath::point2(event.pos.0, event.pos.1)) else {
                 // If transform is ill-formed, we can't do work.
                 return;
             };
 
-            // Calc cumulative distance from the start, or 0.0 if this is the first point.
-            let dist = this_stroke.points.last().map_or(0.0, |last| {
-                let delta = [last.pos[0] - pos.x, last.pos[1] - pos.y];
-                last.dist + (delta[0] * delta[0] + delta[1] * delta[1]).sqrt()
+            builder.push(InputPoint {
+                position: [pos.x, pos.y],
+                time: None,
+                pressure: event.pressure,
+                tilt: event.tilt.map(|(x, y)| [x, y]),
+                distance: event.dist,
+                roll: None,
+                wheel: None,
             });
-
-            this_stroke.points.push(fuzzpaint_core::stroke::Point {
-                pos: [pos.x, pos.y],
-                pressure: event.pressure.unwrap_or(1.0),
-                dist,
-            });
-        } else if let Some(stroke) = in_progress_stroke.take() {
+        } else if !builder.is_empty() {
+            // Not pressed but a stroke exists - just finished, upload it!
             // Insert the stroke into the document.
             if let Some(Err(e)) = crate::global::provider().inspect(document, |queue| {
                 queue.write_with(|write| {
@@ -67,41 +365,55 @@ fn brush(
                     // Get the collection
                     let mut collections = write.stroke_collections();
                     let Some(mut collection_writer) = collections.get_mut(collection_id) else {
-                        anyhow::bail!("Current layer references nonexistant stroke collection")
+                        anyhow::bail!("current layer references nonexistant stroke collection")
                     };
-                    // Huzzah, all is good! Upload stroke, and push it.
-                    let immutable = stroke.make_immutable();
-                    drop(stroke);
 
+                    // Pack and store it away
+                    let stroke = builder.consume();
+                    let points = crate::global::points();
+                    let Some(point_collection) = points.insert(stroke) else {
+                        anyhow::bail!("stroke data too large")
+                    };
                     // Destructure immutable stroke and push it.
                     // Invokes an extra ID allocation, weh
-                    collection_writer.push_back(immutable.brush, immutable.point_collection);
+                    collection_writer.push_back(
+                        fuzzpaint_core::state::StrokeBrushSettings { is_eraser, ..brush },
+                        point_collection,
+                    );
 
                     Ok(())
                 })
             }) {
-                log::warn!("Failed to insert stroke: {e:?}");
+                builder.clear();
+                log::warn!("failed to insert stroke: {e:?}");
             }
         }
     }
-    render_output.render_as = if let Some((stroke, last)) = in_progress_stroke
-        .as_ref()
-        .and_then(|stroke| Some((stroke, stroke.points.last()?)))
-    {
-        let size = last.pressure;
-        // Lerp between spacing and size_mul (matches gpu tess behaviour)
-        let size = stroke.brush.spacing_px * (1.0 - size) + stroke.brush.size_mul * size;
+    render_output.render_as = if builder.is_empty() {
+        render_output.cursor = Some(crate::gizmos::CursorOrInvisible::Icon(
+            winit::window::CursorIcon::Crosshair,
+        ));
+        super::RenderAs::None
+    } else {
+        let base_size = brush.spacing_px;
+        let size_factor = brush.size_mul - brush.spacing_px;
+        let last_pos = builder.position.last().unwrap();
+        let last_size = if let Some(pressure) = builder.pressure.last() {
+            pressure * size_factor + base_size
+        } else {
+            brush.size_mul
+        };
 
-        let gizmo = crate::gizmos::Gizmo {
+        let brush_tip = crate::gizmos::Gizmo {
             visual: crate::gizmos::Visual {
                 mesh: crate::gizmos::MeshMode::Shape(crate::gizmos::RenderShape::Ellipse {
                     origin: ultraviolet::Vec2 {
-                        x: last.pos[0],
-                        y: last.pos[1],
+                        x: last_pos[0],
+                        y: last_pos[1],
                     },
                     radii: ultraviolet::Vec2 {
-                        x: size / 2.0,
-                        y: size / 2.0,
+                        x: last_size / 2.0,
+                        y: last_size / 2.0,
                     },
                     rotation: 0.0,
                 }),
@@ -111,59 +423,76 @@ fn brush(
         };
         render_output.cursor = Some(crate::gizmos::CursorOrInvisible::Invisible);
         super::RenderAs::InlineGizmos(
-            [make_trail(in_progress_stroke.as_ref().unwrap()), gizmo]
-                .into_iter()
-                .collect(),
+            [
+                make_trail(
+                    builder,
+                    base_size,
+                    size_factor,
+                    if is_eraser {
+                        None
+                    } else {
+                        Some(brush.color_modulate)
+                    },
+                ),
+                brush_tip,
+            ]
+            .into_iter()
+            .collect(),
         )
-    } else {
-        render_output.cursor = Some(crate::gizmos::CursorOrInvisible::Icon(
-            winit::window::CursorIcon::Crosshair,
-        ));
-        super::RenderAs::None
     }
 }
-fn make_trail(stroke: &crate::Stroke) -> crate::gizmos::Gizmo {
+fn make_trail(
+    stroke: &StrokeBuilder,
+    min_size: f32,
+    size_factor: f32,
+    color: Option<[f32; 4]>,
+) -> crate::gizmos::Gizmo {
     use crate::gizmos::{transform::Transform, Gizmo, MeshMode, TextureMode, Visual};
 
-    let mut points = Vec::with_capacity(stroke.points.len());
-    let pressure_scale = stroke.brush.size_mul - stroke.brush.spacing_px;
-    let pressure_offs = stroke.brush.spacing_px;
+    // Make trail:
+    let mut points = Vec::with_capacity(stroke.len());
+    // Fill in positions at 100% size
     points.extend(
         stroke
-            .points
+            .position
             .iter()
-            .map(|point| crate::gizmos::renderer::WideLineVertex {
-                pos: point.pos,
+            .map(|&pos| crate::gizmos::renderer::WideLineVertex {
+                pos,
                 // We use gizmo global color for this
                 color: [255; 4],
                 tex_coord: 0.0,
-                width: point.pressure.mul_add(pressure_scale, pressure_offs),
+                width: min_size + size_factor,
             }),
     );
 
-    let texture = if stroke.brush.is_eraser {
-        TextureMode::AntTrail
-    } else {
-        let color = stroke.brush.color_modulate;
-        // unmultiply
-        let color = if color[3].abs() > 0.001 {
-            [
-                color[0] / color[3],
-                color[1] / color[3],
-                color[2] / color[3],
-                color[3],
-            ]
-        } else {
-            // Avoid div by zero
-            [0.0; 4]
-        };
-        let color = [
-            (color[0].clamp(0.0, 1.0) * 255.9999) as u8,
-            (color[1].clamp(0.0, 1.0) * 255.9999) as u8,
-            (color[2].clamp(0.0, 1.0) * 255.9999) as u8,
-            (color[3].clamp(0.0, 1.0) * 255.9999) as u8,
-        ];
-        TextureMode::Solid(color)
+    // Go back to fill in sizes if known
+    if !stroke.pressure.is_empty() {
+        points
+            .iter_mut()
+            .zip(stroke.pressure.iter())
+            .for_each(|(point, pressure)| {
+                point.width = pressure.mul_add(size_factor, min_size);
+            });
+    }
+
+    let texture = match color {
+        Some([r, g, b, a]) => {
+            // unmultiply
+            let color = if a.abs() > 0.001 {
+                [r / a, g / a, b / a, a]
+            } else {
+                // Avoid div by zero
+                [0.0; 4]
+            };
+            let color = [
+                (color[0].clamp(0.0, 1.0) * 255.9999) as u8,
+                (color[1].clamp(0.0, 1.0) * 255.9999) as u8,
+                (color[2].clamp(0.0, 1.0) * 255.9999) as u8,
+                (color[3].clamp(0.0, 1.0) * 255.9999) as u8,
+            ];
+            TextureMode::Solid(color)
+        }
+        None => TextureMode::AntTrail,
     };
 
     Gizmo {
@@ -177,10 +506,10 @@ fn make_trail(stroke: &crate::Stroke) -> crate::gizmos::Gizmo {
 }
 
 pub struct Brush {
-    in_progress_stroke: Option<crate::Stroke>,
+    stroke: StrokeBuilder,
 }
 pub struct Eraser {
-    in_progress_stroke: Option<crate::Stroke>,
+    stroke: StrokeBuilder,
 }
 
 impl super::MakePenTool for Brush {
@@ -188,7 +517,7 @@ impl super::MakePenTool for Brush {
         _: &std::sync::Arc<crate::render_device::RenderContext>,
     ) -> anyhow::Result<Box<dyn super::PenTool>> {
         Ok(Box::new(Brush {
-            in_progress_stroke: None,
+            stroke: StrokeBuilder::default(),
         }))
     }
 }
@@ -197,7 +526,7 @@ impl super::MakePenTool for Eraser {
         _: &std::sync::Arc<crate::render_device::RenderContext>,
     ) -> anyhow::Result<Box<dyn super::PenTool>> {
         Ok(Box::new(Eraser {
-            in_progress_stroke: None,
+            stroke: StrokeBuilder::default(),
         }))
     }
 }
@@ -205,7 +534,7 @@ impl super::MakePenTool for Eraser {
 #[async_trait::async_trait]
 impl super::PenTool for Brush {
     fn exit(&mut self) {
-        self.in_progress_stroke = None;
+        self.stroke.clear();
     }
     async fn process(
         &mut self,
@@ -217,7 +546,7 @@ impl super::PenTool for Brush {
     ) {
         brush(
             actions.is_action_held(crate::actions::Action::Erase),
-            &mut self.in_progress_stroke,
+            &mut self.stroke,
             view_info,
             stylus_input,
             render_output,
@@ -228,7 +557,7 @@ impl super::PenTool for Brush {
 #[async_trait::async_trait]
 impl super::PenTool for Eraser {
     fn exit(&mut self) {
-        self.in_progress_stroke = None;
+        self.stroke.clear();
     }
     async fn process(
         &mut self,
@@ -240,7 +569,7 @@ impl super::PenTool for Eraser {
     ) {
         brush(
             true,
-            &mut self.in_progress_stroke,
+            &mut self.stroke,
             view_info,
             stylus_input,
             render_output,

--- a/fuzzpaint/src/shaders/tessellate_stamp.comp
+++ b/fuzzpaint/src/shaders/tessellate_stamp.comp
@@ -5,8 +5,10 @@ const float PI = 3.1415926535897932384;
 
 struct InputStrokeInfo {
     // Indices into inputStrokeVertices buffer
-    uint start_point_idx;
+    uint base_element_offset;
     uint num_points;
+    // Structure of input data. Determines size of each point.
+    uint archetype;
 
     // Indices into outputStrokeVertices
     uint out_vert_offset;
@@ -30,6 +32,44 @@ struct InputStrokeVertex {
     float dist;
 };
 
+// Bitmasks for archetype flags. Matches constants of [`fuzzpaint_core::stroke::Archetype`]
+const uint ARCH_POSITION = 1;
+const uint ARCH_TIME = 2;
+const uint ARCH_ARC_LENGTH = 4;
+const uint ARCH_PRESSURE = 8;
+const uint ARCH_TILT = 16;
+const uint ARCH_DISTANCE = 32;
+const uint ARCH_ROLL = 64;
+const uint ARCH_WHEEL = 128;
+
+/// Count the number of bits set.
+uint popcnt(in uint i) {
+    // https://stackoverflow.com/a/109025
+
+    i = i - ((i >> 1) & 0x55555555);                // add pairs of bits
+    i = (i & 0x33333333) + ((i >> 2) & 0x33333333); // quads
+    i = (i + (i >> 4)) & 0x0F0F0F0F;                // groups of 8
+    i *= 0x01010101;                                // horizontal sum of bytes
+    return  i >> 24;                                // return just that top byte (after truncating to 32-bit even when int is wider than uint32_t)
+}
+
+/// Calc the number of 32-bit elements in a single point of the given archetype
+uint archetype_elements(in uint archetype) {
+    // Every bit adds one elem...
+    return popcnt(archetype) + \
+        // POS, TILT add an extra!
+        ((archetype & ARCH_POSITION) != 0 ? 1 : 0) + \
+        ((archetype & ARCH_TILT) != 0 ? 1 : 0);
+}
+
+/// Find the index where `which` is located within a point of type `archetype`.
+/// `which` must contain a single bit. Meaningless if `archetype` doesn't contain `which`.
+uint archetype_offset_of(in uint archetype, in uint which) {
+    // index of x == length of all elems that come before x
+    // (which - 1) yields a bitmask of all elems before, given that it has a single bit set.
+    return archetype_elements(archetype & (which - 1));
+}
+
 // Corresponds to VkDrawIndirectCommand
 const uint OUTPUT_INFO_SIZE = 4;
 const uint OUTPUT_INFO_VERTEX_COUNT = 0;
@@ -51,8 +91,9 @@ layout(set = 0, binding = 0) restrict readonly buffer inputStrokeInfo {
 layout(set = 0, binding = 1) restrict readonly buffer inputWorkgroupAssignments {
     uint in_assignments[];
 };
-layout(set = 0, binding = 2) restrict readonly buffer inputStrokeVertices {
-    InputStrokeVertex in_vertices[];
+// Packed elements of the points of strokes. Interpretation is based on the archetype of each stroke.
+layout(set = 0, binding = 2) restrict readonly buffer inputStrokePoints {
+    uint in_elements[];
 };
 
 // Input data - corresponding to [tess::TessellatedStrokeInfo] and [tess::TessellatedStrokeVertex]
@@ -125,6 +166,26 @@ void main() {
     const InputStrokeInfo info = in_info[stroke_idx];
     if (info.num_points <= 2) return;
 
+    // Calculate the sizes and offsets of properties based on the archetype.
+    // These two are currently required. Enforced by the CPU-side.
+    const uint position_element_offset = archetype_offset_of(info.archetype, ARCH_POSITION);
+    const uint arclen_element_offset = archetype_offset_of(info.archetype, ARCH_ARC_LENGTH);
+    // Pressure is optional
+    const bool has_pressure = (info.archetype & ARCH_PRESSURE) != 0;
+    // Meaningless (+maybe OOB!) if has_pressure is false
+    const uint pressure_element_offset = archetype_offset_of(info.archetype, ARCH_PRESSURE);
+    const uint point_element_len = archetype_elements(info.archetype);
+
+    // Macros to fetch and decode data of the nth point of this workgroup's stroke.
+    // These rely on local constants, unsanitary!
+    #define LOCAL_PRESSURE_ELEMENT_OR_ONE(idx) (\
+        has_pressure ? uintBitsToFloat(in_elements[info.base_element_offset + ((idx) * point_element_len) + pressure_element_offset]) : 1.0\
+    )
+    #define LOCAL_POSITION_ELEMENT(idx) vec2(\
+        uintBitsToFloat(in_elements[info.base_element_offset + ((idx) * point_element_len) + position_element_offset]),\
+        uintBitsToFloat(in_elements[info.base_element_offset + ((idx) * point_element_len) + position_element_offset + 1])\
+    )
+    #define LOCAL_ARCLEN_ELEMENT(idx) uintBitsToFloat(in_elements[info.base_element_offset + ((idx) * point_element_len) + arclen_element_offset])
 
     // 0 at the start of the stroke given by `info`
     const uint stroke_local_id = (workgroup_idx - info.start_group) * gl_WorkGroupSize.x + gl_LocalInvocationID.x;
@@ -141,14 +202,14 @@ void main() {
     // One worker per group is the local leader, coordinates writes to vertex_count in infos.
     const bool is_local_leader = gl_LocalInvocationID.x == 0;
 
-    const float end_dist = in_vertices[info.start_point_idx + info.num_points - 1].dist;
+    // const float end_arclen = in_elements[info.base_element_offset + info.num_points * point_element_len + arclen_element_offset];
 
-    // const float local_dist = float(stroke_local_id) * (end_dist / float(info.num_groups * gl_WorkGroupSize.x));
-    const float local_dist = float(stroke_local_id) * info.density;
+    // const float local_arclen = float(stroke_local_id) * (end_arclen / float(info.num_groups * gl_WorkGroupSize.x));
+    const float local_arclen = float(stroke_local_id) * info.density;
 
     // Binary search for the vertex this worker starts from
     // A worker cannot work after the last vertex, so -2 here.
-    uint bail = 0, low = info.start_point_idx, high = info.start_point_idx + info.num_points - 2;
+    uint bail = 0, low = 0, high = info.num_points - 2;
     uint before_vert = 0;
     while (true) {
         if (low > high || bail++ > 32) {
@@ -158,9 +219,9 @@ void main() {
 
         // Next point exists and is too early
         // (mid+1 is safe because upper bound is num_points-2)
-        const bool strictly_less = (in_vertices[mid + 1].dist < local_dist);
+        const bool strictly_less = LOCAL_ARCLEN_ELEMENT(mid + 1) < local_arclen;
         // This point is too far
-        const bool strictly_greater = in_vertices[mid].dist > local_dist;
+        const bool strictly_greater = LOCAL_ARCLEN_ELEMENT(mid) > local_arclen;
 
         if (strictly_less) {
             low = mid + 1;
@@ -174,12 +235,20 @@ void main() {
 
     // We've now done all the very expensive work to figure out what to work on.
     // Now to do some bulk work to amortize that expense xP
-    const InputStrokeVertex a_vert = in_vertices[before_vert];
-    const InputStrokeVertex b_vert = in_vertices[before_vert + 1];
+    const InputStrokeVertex a_vert = InputStrokeVertex(
+        LOCAL_POSITION_ELEMENT(before_vert),
+        LOCAL_PRESSURE_ELEMENT_OR_ONE(before_vert),
+        LOCAL_ARCLEN_ELEMENT(before_vert)
+    );
+    const InputStrokeVertex b_vert = InputStrokeVertex(
+        LOCAL_POSITION_ELEMENT(before_vert + 1),
+        LOCAL_PRESSURE_ELEMENT_OR_ONE(before_vert + 1),
+        LOCAL_ARCLEN_ELEMENT(before_vert + 1)
+    );
     const vec4 a = vert_to_simd(a_vert);
     const vec4 b = vert_to_simd(b_vert);
     // 0.0..1.0 range of where this worker falls between previous and next vert
-    const float factor = (local_dist - a_vert.dist) / (b_vert.dist - a_vert.dist);
+    const float factor = (local_arclen - a_vert.dist) / (b_vert.dist - a_vert.dist);
     const InputStrokeVertex interp = simd_to_vert(mix(a, b, factor));
 
     // Create a stamp


### PR DESCRIPTION
Allows the layout and size of strokes and points to be dynamic on a per-stroke basis (within certain bounds).
The basic outline of this idea has been in place for a long time but nonetheless the code still had most parts hardcoded to work with Position + Pressure + Arclen, but now things properly respect the eight axes/ten elements currently defined (Position Time, Arclen, Pressure, Tilt, Distance, Roll, Wheel).

By making the structure dynamic in this way, more expression can be added to the brush engine by allowing them to access these new axes, without making devices without support have the extra disk space/memory overhead of all those `None` values. A mouse only creates `(x,y,arclen)` elements per point, where a cintiq might produce `(x,y,arclen,pressure,tiltx,tilty,distance,roll)`.