### PR TITLE
Fullscreen fix

### DIFF
--- a/fuzzpaint/src/document_viewport_proxy.rs
+++ b/fuzzpaint/src/document_viewport_proxy.rs
@@ -454,7 +454,7 @@ impl Proxy {
                 .then_signal_fence_and_flush()?
         };
         // Wait on the future at the end of init
-        defer::defer(move || initialize_future.wait(None).unwrap());
+        let _defer = defer::defer(move || initialize_future.wait(None).unwrap());
 
         let document_image_views = [
             vk::ImageView::new(

--- a/fuzzpaint/src/egui_impl.rs
+++ b/fuzzpaint/src/egui_impl.rs
@@ -528,7 +528,7 @@ impl Render {
                     .subresource_range()
                     .clone()],
                 ..vk::ClearColorImageInfo::image(framebuffer.attachments()[0].image().clone())
-            });
+            })?;
         }
         command_buffer_builder
             .begin_render_pass(

--- a/fuzzpaint/src/egui_impl.rs
+++ b/fuzzpaint/src/egui_impl.rs
@@ -167,6 +167,7 @@ impl Ctx {
     pub fn build_commands(
         &mut self,
         swapchain_idx: u32,
+        clear: bool,
     ) -> Option<(
         Option<Arc<vk::PrimaryAutoCommandBuffer>>,
         Arc<vk::PrimaryAutoCommandBuffer>,
@@ -178,7 +179,7 @@ impl Ctx {
         let res: AnyResult<_> = try_block::try_block! {
             let transfer_commands = self.renderer.do_image_deltas(output.textures_delta).transpose()?;
             let tess_geom = self.state.egui_ctx().tessellate(output.shapes, output.pixels_per_point);
-            let draw_commands = self.renderer.upload_and_render(output.pixels_per_point, swapchain_idx, &tess_geom)?;
+            let draw_commands = self.renderer.upload_and_render(output.pixels_per_point, swapchain_idx, &tess_geom, clear)?;
             drop(tess_geom);
 
             Ok((transfer_commands, draw_commands))
@@ -437,6 +438,7 @@ impl Render {
         scale_factor: f32,
         present_img_index: u32,
         tesselated_geom: &[egui::epaint::ClippedPrimitive],
+        clear: bool,
     ) -> anyhow::Result<Arc<vk::PrimaryAutoCommandBuffer>> {
         let mut vert_buff_size = 0;
         let mut index_buff_size = 0;
@@ -519,6 +521,15 @@ impl Render {
             self.context.queues().graphics().idx(),
             vk::CommandBufferUsage::OneTimeSubmit,
         )?;
+        if clear {
+            command_buffer_builder.clear_color_image(vk::ClearColorImageInfo {
+                clear_value: [0.0, 0.0, 0.0, 1.0].into(),
+                regions: smallvec::smallvec![framebuffer.attachments()[0]
+                    .subresource_range()
+                    .clone()],
+                ..vk::ClearColorImageInfo::image(framebuffer.attachments()[0].image().clone())
+            });
+        }
         command_buffer_builder
             .begin_render_pass(
                 vk::RenderPassBeginInfo {

--- a/fuzzpaint/src/window.rs
+++ b/fuzzpaint/src/window.rs
@@ -344,12 +344,6 @@ impl Renderer {
         // Print a warning if swapchain image future is dropped. Per a dire warning in the comments of vulkano,
         // dropping futures can result in that swapchain image being lost forever...!
         let bail_warning = defer::defer(|| log::warn!("Dropped swapchain future."));
-        // After we present, recreate if suboptimal.
-        defer::defer(|| {
-            if suboptimal {
-                self.recreate_surface().unwrap();
-            }
-        });
         let commands = self.egui_ctx.build_commands(idx);
 
         //Wait for previous frame to end. (required for safety of preview render proxy)
@@ -448,6 +442,11 @@ impl Renderer {
         std::mem::forget(bail_warning);
 
         self.last_frame_fence = Some(next_frame_future);
+
+        // After we present, recreate if suboptimal.
+        if suboptimal {
+            self.recreate_surface().unwrap();
+        }
 
         Ok(())
     }

--- a/fuzzpaint/src/window.rs
+++ b/fuzzpaint/src/window.rs
@@ -344,7 +344,6 @@ impl Renderer {
         // Print a warning if swapchain image future is dropped. Per a dire warning in the comments of vulkano,
         // dropping futures can result in that swapchain image being lost forever...!
         let bail_warning = defer::defer(|| log::warn!("Dropped swapchain future."));
-        let commands = self.egui_ctx.build_commands(idx);
 
         //Wait for previous frame to end. (required for safety of preview render proxy)
         self.last_frame_fence.take().map(|fence| fence.wait(None));
@@ -363,6 +362,12 @@ impl Renderer {
                 smallvec::SmallVec::new()
             }
         };
+
+        let commands = self
+            .egui_ctx
+            // Preview commands are responsible for turning the UNDEFINED image into a well-defined state.
+            // If there are none, instruct egui renderer to clear it first.
+            .build_commands(idx, preview_commands.is_empty());
 
         let render_complete = match commands {
             Some((Some(transfer), draw)) => {


### PR DESCRIPTION
Closes #43

Turns out the crash under exclusive fullscreen had nothing to do with exclusive fullscreen per-se - a typo in the suboptimal swapchain handling meant that any time it was made suboptimal it would cause a delayed crash. Several such typos were present elsewhere too, yikes.

Also fixes the flickering document view when resizing, which turned out to be some nasty UB from `LoadOp::Load`-ing an uninitialized image inside the egui renderer.