### PR TITLE
Basic layer transforms

### DIFF
--- a/fuzzpaint-core/src/io/mod.rs
+++ b/fuzzpaint-core/src/io/mod.rs
@@ -251,6 +251,8 @@ pub fn read_path<Path: Into<std::path::PathBuf>>(
     );
     let my_node = crate::state::graph::LeafType::StrokeLayer {
         blend: crate::blend::Blend::default(),
+        inner_transform: crate::state::transform::Similarity::default(),
+        outer_transform: crate::state::transform::Matrix::default(),
         collection: my_collection,
     };
     let mut my_graph = crate::state::graph::BlendGraph::default();

--- a/fuzzpaint-core/src/state/graph/commands.rs
+++ b/fuzzpaint-core/src/state/graph/commands.rs
@@ -21,6 +21,16 @@ pub enum Command {
         destination: Option<super::NodeID>,
         child_idx: usize,
     },
+    LeafInnerTransformChanged {
+        target: super::LeafID,
+        old_transform: super::transform::Similarity,
+        new_transform: super::transform::Similarity,
+    },
+    LeafOuterTransformChanged {
+        target: super::LeafID,
+        old_transform: super::transform::Matrix,
+        new_transform: super::transform::Matrix,
+    },
     LeafTyChanged {
         target: super::LeafID,
         old_ty: super::LeafType,

--- a/fuzzpaint-core/src/state/graph/mod.rs
+++ b/fuzzpaint-core/src/state/graph/mod.rs
@@ -7,6 +7,7 @@ pub mod commands;
 mod stable_id;
 pub mod writer;
 
+use super::transform;
 use crate::blend::Blend;
 // Re-export the various public ids
 // FuzzNodeID is NOT public!
@@ -17,6 +18,10 @@ pub enum LeafType {
     StrokeLayer {
         blend: Blend,
         collection: crate::state::stroke_collection::StrokeCollectionID,
+        /// Transform points before tessellation.
+        inner_transform: transform::Similarity,
+        /// Tramsform points after tessellation.
+        outer_transform: transform::Matrix,
     },
     SolidColor {
         blend: Blend,
@@ -31,6 +36,7 @@ pub enum LeafType {
         // "em" is a physical unit. Currently, we have no means to deal with this fact.
         // Allow the user to specify manually.
         px_per_em: f32,
+        outer_transform: transform::Matrix,
     },
     // The name of the note is the note!
     Note,
@@ -569,6 +575,71 @@ impl crate::commands::CommandConsumer<commands::Command> for BlendGraph {
                 }
                 *blend = *to;
                 Ok(())
+            }
+            DoUndo::Do(Command::LeafInnerTransformChanged {
+                target,
+                old_transform,
+                new_transform,
+            })
+            | DoUndo::Undo(Command::LeafInnerTransformChanged {
+                target,
+                old_transform: new_transform,
+                new_transform: old_transform,
+            }) => {
+                let Some(node) = self.get_leaf_mut(*target) else {
+                    return Err(CommandError::UnknownResource);
+                };
+
+                match node {
+                    LeafType::StrokeLayer {
+                        inner_transform, ..
+                    } => {
+                        // If NaN This becomes problematic.
+                        if inner_transform != old_transform {
+                            Err(CommandError::MismatchedState)
+                        } else {
+                            *inner_transform = *new_transform;
+                            Ok(())
+                        }
+                    }
+                    LeafType::Note | LeafType::SolidColor { .. } | LeafType::Text { .. } => {
+                        Err(CommandError::MismatchedState)
+                    }
+                }
+            }
+            DoUndo::Do(Command::LeafOuterTransformChanged {
+                target,
+                old_transform,
+                new_transform,
+            })
+            | DoUndo::Undo(Command::LeafOuterTransformChanged {
+                target,
+                old_transform: new_transform,
+                new_transform: old_transform,
+            }) => {
+                let Some(node) = self.get_leaf_mut(*target) else {
+                    return Err(CommandError::UnknownResource);
+                };
+
+                match node {
+                    LeafType::StrokeLayer {
+                        outer_transform, ..
+                    }
+                    | LeafType::Text {
+                        outer_transform, ..
+                    } => {
+                        // If NaN This becomes problematic.
+                        if outer_transform != old_transform {
+                            Err(CommandError::MismatchedState)
+                        } else {
+                            *outer_transform = *new_transform;
+                            Ok(())
+                        }
+                    }
+                    LeafType::Note | LeafType::SolidColor { .. } => {
+                        Err(CommandError::MismatchedState)
+                    }
+                }
             }
             DoUndo::Do(Command::LeafTyChanged { target, old_ty, ty })
             | DoUndo::Undo(Command::LeafTyChanged {

--- a/fuzzpaint-core/src/state/graph/mod.rs
+++ b/fuzzpaint-core/src/state/graph/mod.rs
@@ -59,6 +59,25 @@ impl LeafType {
             Self::Note => None,
         }
     }
+    pub fn inner_transform_mut(&mut self) -> Option<&mut transform::Similarity> {
+        match self {
+            Self::StrokeLayer {
+                inner_transform, ..
+            } => Some(inner_transform),
+            Self::Note | Self::SolidColor { .. } | Self::Text { .. } => None,
+        }
+    }
+    pub fn outer_transform_mut(&mut self) -> Option<&mut transform::Matrix> {
+        match self {
+            Self::StrokeLayer {
+                outer_transform, ..
+            }
+            | Self::Text {
+                outer_transform, ..
+            } => Some(outer_transform),
+            Self::Note | Self::SolidColor { .. } => None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Debug)]
 pub enum NodeType {

--- a/fuzzpaint-core/src/state/mod.rs
+++ b/fuzzpaint-core/src/state/mod.rs
@@ -6,6 +6,7 @@ pub mod graph;
 pub mod palette;
 pub mod rich_text;
 pub mod stroke_collection;
+pub mod transform;
 
 pub type DocumentID = crate::FuzzID<Document>;
 

--- a/fuzzpaint-core/src/state/transform/mod.rs
+++ b/fuzzpaint-core/src/state/transform/mod.rs
@@ -1,0 +1,86 @@
+/// A transform consisting of an optional horizontal flip, then uniform scale,
+/// then rotation, then translation.
+///
+/// This transform maintains the "Similarity" of shapes and their image, maintaining
+/// all angles and the ratios between all lengths.
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable, PartialEq, PartialOrd)]
+#[repr(C)]
+pub struct Similarity {
+    /// Special interpretation: Negative bit set == hflip.
+    /// Uniform scale should occur as abs(scale).
+    pub flip_scale: f32,
+    /// Rotation, in radians *CW* from positive X
+    pub rotation: f32,
+    /// Translation, in logical pixels. 0,0 is top left, +X Right, +Y down.
+    pub translation: [f32; 2],
+}
+
+impl Similarity {
+    #[must_use]
+    pub fn hflip(&self) -> bool {
+        // We want the literal sign bit, regardless of the numerical interpretation.
+        self.flip_scale.is_sign_negative()
+    }
+    #[must_use]
+    pub fn scale(&self) -> f32 {
+        self.flip_scale.abs()
+    }
+}
+
+impl Default for Similarity {
+    fn default() -> Self {
+        Self {
+            flip_scale: 1.0,
+            rotation: 0.0,
+            translation: [0.0; 2],
+        }
+    }
+}
+
+/// An arbitrary transform. Units of output are logical pixels.
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable, PartialEq, PartialOrd)]
+#[repr(C)]
+pub struct Matrix {
+    /// Column-major matrix elements
+    pub elements: [[f32; 2]; 3],
+}
+
+impl Default for Matrix {
+    fn default() -> Self {
+        Self {
+            elements: [[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]],
+        }
+    }
+}
+
+impl From<Similarity> for Matrix {
+    fn from(value: Similarity) -> Self {
+        // We want the flip bit to mean negative--
+        // wait a minute, the flip bit is already stored there!
+        let h_scale = value.flip_scale;
+        let v_scale = value.scale();
+
+        let (sin, cos) = value.rotation.sin_cos();
+
+        Self {
+            // Scale times rotation, and then translate.
+            elements: [
+                [h_scale * cos, v_scale * sin],
+                [h_scale * -sin, v_scale * cos],
+                value.translation,
+            ],
+        }
+    }
+}
+
+impl From<[[f32; 2]; 3]> for Matrix {
+    fn from(elements: [[f32; 2]; 3]) -> Self {
+        Self { elements }
+    }
+}
+
+impl From<Matrix> for [[f32; 2]; 3] {
+    fn from(value: Matrix) -> Self {
+        value.elements
+    }
+}

--- a/fuzzpaint-core/src/state/transform/mod.rs
+++ b/fuzzpaint-core/src/state/transform/mod.rs
@@ -45,6 +45,32 @@ pub struct Matrix {
     pub elements: [[f32; 2]; 3],
 }
 
+impl Matrix {
+    #[must_use = "Returns a new matrix and does not modify self"]
+    pub fn then(&self, other: &Self) -> Self {
+        // Compute other * self.
+        // Ordered this way for plain english purposes :P
+        let r = &self.elements;
+        let l = &other.elements;
+        Self {
+            elements: [
+                [
+                    r[0][0] * l[0][0] + r[0][1] * l[1][0],
+                    r[0][0] * l[0][1] + r[0][1] * l[1][1],
+                ],
+                [
+                    r[1][0] * l[0][0] + r[1][1] * l[1][0],
+                    r[1][0] * l[0][1] + r[1][1] * l[1][1],
+                ],
+                [
+                    r[2][0] * l[0][0] + r[2][1] * l[1][0] + l[2][0],
+                    r[2][0] * l[0][1] + r[2][1] * l[1][1] + l[2][1],
+                ],
+            ],
+        }
+    }
+}
+
 impl Default for Matrix {
     fn default() -> Self {
         Self {

--- a/fuzzpaint/src/pen_tools/brush.rs
+++ b/fuzzpaint/src/pen_tools/brush.rs
@@ -446,7 +446,7 @@ fn brush(
             .map_or(1.0, |xform| xform.preview_scale);
 
         let base_size = transform_scale_factor * brush.spacing_px.get();
-        let size_factor = transform_scale_factor * (brush.size_mul.get() - base_size);
+        let size_factor = transform_scale_factor * brush.size_mul.get() - base_size;
 
         // Calculate size for circular mouse cursor
         let last_pos = builder.position.last().unwrap();
@@ -578,12 +578,9 @@ impl TransformInfo {
         inner: &fuzzpaint_core::state::transform::Similarity,
         outer: &fuzzpaint_core::state::transform::Matrix,
     ) -> Self {
-        let det_inner = inner.scale();
         // det(basis2 of outer) -- Not the same as det(outer)!
         let det_outer = outer.elements[0][0] * outer.elements[1][1]
             + outer.elements[1][0] * outer.elements[0][1];
-
-        let preview_scale = det_inner * det_outer;
 
         let total = fuzzpaint_core::state::transform::Matrix::from(*inner).then(outer);
         let total = ultraviolet::Mat3 {
@@ -609,7 +606,7 @@ impl TransformInfo {
         let inverse = total.inversed();
 
         Self {
-            preview_scale,
+            preview_scale: det_outer.sqrt(),
             inverse,
         }
     }

--- a/fuzzpaint/src/renderer/gpu_tess.rs
+++ b/fuzzpaint/src/renderer/gpu_tess.rs
@@ -82,11 +82,17 @@ impl GpuStampTess {
             },
         )?;
 
+        let inner_transform_constant = vk::PushConstantRange {
+            stages: vk::ShaderStages::COMPUTE,
+            offset: 0,
+            size: std::mem::size_of::<[[f32; 2]; 3]>().try_into().unwrap(),
+        };
+
         Ok((
             vk::PipelineLayout::new(
                 device,
                 vk::PipelineLayoutCreateInfo {
-                    push_constant_ranges: Vec::new(),
+                    push_constant_ranges: vec![inner_transform_constant],
                     set_layouts: vec![inputs.clone(), outputs.clone()],
                     ..Default::default()
                 },
@@ -139,12 +145,17 @@ impl GpuStampTess {
     pub fn tess_batch(
         &self,
         batch: &crate::renderer::stroke_batcher::StrokeBatch,
+        // Transform to perform on points *before* tessellation.
+        inner_transform: &fuzzpaint_core::state::transform::Similarity,
         // TODO: implement.
         _take_scratch: bool,
     ) -> anyhow::Result<Option<TessOutput<impl GpuFuture>>> {
         #![allow(clippy::too_many_lines)]
         let mut group_index_counter = 0;
         let mut vertex_output_index_counter = 0;
+
+        // All lengths are uniformly scaled by this, thus all arclengths are too!
+        let distance_scale = inner_transform.scale();
 
         // For each info, how many workgroups are dispatched for it?
         let mut num_groups_per_info = Vec::with_capacity(batch.allocs.len());
@@ -172,6 +183,7 @@ impl GpuStampTess {
                 let num_expected_stamps = alloc
                     .summary
                     .arc_length
+                    .map(|arc_length| arc_length * distance_scale)
                     .map_or(0, |arc_length| (arc_length / density).ceil() as u32);
 
                 let num_points = alloc.summary.len as u32;
@@ -301,6 +313,14 @@ impl GpuStampTess {
         command_buffer
             .fill_buffer(output_infos.clone().reinterpret(), 0u32)?
             .bind_pipeline_compute(self.pipeline.clone())?
+            .push_constants(
+                self.layout.clone(),
+                0,
+                // Similarity -> Matrix -> floats. :P
+                <[[f32; 2]; 3]>::from(fuzzpaint_core::state::transform::Matrix::from(
+                    *inner_transform,
+                )),
+            )?
             .bind_descriptor_sets(
                 vk::PipelineBindPoint::Compute,
                 self.layout.clone(),

--- a/fuzzpaint/src/renderer/gpu_tess.rs
+++ b/fuzzpaint/src/renderer/gpu_tess.rs
@@ -85,7 +85,7 @@ impl GpuStampTess {
         let inner_transform_constant = vk::PushConstantRange {
             stages: vk::ShaderStages::COMPUTE,
             offset: 0,
-            size: std::mem::size_of::<[[f32; 2]; 3]>().try_into().unwrap(),
+            size: std::mem::size_of::<[[f32; 2]; 3]>() as u32 + std::mem::size_of::<f32>() as u32,
         };
 
         Ok((
@@ -316,10 +316,14 @@ impl GpuStampTess {
             .push_constants(
                 self.layout.clone(),
                 0,
-                // Similarity -> Matrix -> floats. :P
-                <[[f32; 2]; 3]>::from(fuzzpaint_core::state::transform::Matrix::from(
-                    *inner_transform,
-                )),
+                shaders::tessellate::InnerTransform {
+                    // Similarity -> Matrix -> floats. :P
+                    inner_transform: fuzzpaint_core::state::transform::Matrix::from(
+                        *inner_transform,
+                    )
+                    .into(),
+                    arclen_scale: inner_transform.scale(),
+                },
             )?
             .bind_descriptor_sets(
                 vk::PipelineBindPoint::Compute,

--- a/fuzzpaint/src/shaders/tessellate_stamp.comp
+++ b/fuzzpaint/src/shaders/tessellate_stamp.comp
@@ -112,6 +112,11 @@ layout(set = 1, binding = 1) restrict writeonly buffer outputStrokeVertices {
 // The worker responsible for the first vertex is the "leader"
 layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
 
+// Transform to perform on input points before tess.
+layout(push_constant) uniform InnerTransform {
+    mat3x2 inner_transform;
+};
+
 vec4 vert_to_simd(in InputStrokeVertex v) {
     return vec4(
         v.pos.xy,
@@ -235,16 +240,21 @@ void main() {
 
     // We've now done all the very expensive work to figure out what to work on.
     // Now to do some bulk work to amortize that expense xP
-    const InputStrokeVertex a_vert = InputStrokeVertex(
+    InputStrokeVertex a_vert = InputStrokeVertex(
         LOCAL_POSITION_ELEMENT(before_vert),
         LOCAL_PRESSURE_ELEMENT_OR_ONE(before_vert),
         LOCAL_ARCLEN_ELEMENT(before_vert)
     );
-    const InputStrokeVertex b_vert = InputStrokeVertex(
+    InputStrokeVertex b_vert = InputStrokeVertex(
         LOCAL_POSITION_ELEMENT(before_vert + 1),
         LOCAL_PRESSURE_ELEMENT_OR_ONE(before_vert + 1),
         LOCAL_ARCLEN_ELEMENT(before_vert + 1)
     );
+
+    // Transform input points.
+    a_vert.pos = (inner_transform * vec3(a_vert.pos, 1.0)).xy;
+    b_vert.pos = (inner_transform * vec3(b_vert.pos, 1.0)).xy;
+
     const vec4 a = vert_to_simd(a_vert);
     const vec4 b = vert_to_simd(b_vert);
     // 0.0..1.0 range of where this worker falls between previous and next vert

--- a/fuzzpaint/src/shaders/tessellate_stamp.comp
+++ b/fuzzpaint/src/shaders/tessellate_stamp.comp
@@ -115,6 +115,7 @@ layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
 // Transform to perform on input points before tess.
 layout(push_constant) uniform InnerTransform {
     mat3x2 inner_transform;
+    float arclen_scale;
 };
 
 vec4 vert_to_simd(in InputStrokeVertex v) {
@@ -190,7 +191,7 @@ void main() {
         uintBitsToFloat(in_elements[info.base_element_offset + ((idx) * point_element_len) + position_element_offset]),\
         uintBitsToFloat(in_elements[info.base_element_offset + ((idx) * point_element_len) + position_element_offset + 1])\
     )
-    #define LOCAL_ARCLEN_ELEMENT(idx) uintBitsToFloat(in_elements[info.base_element_offset + ((idx) * point_element_len) + arclen_element_offset])
+    #define LOCAL_ARCLEN_ELEMENT(idx) (uintBitsToFloat(in_elements[info.base_element_offset + ((idx) * point_element_len) + arclen_element_offset]) * arclen_scale)
 
     // 0 at the start of the stroke given by `info`
     const uint stroke_local_id = (workgroup_idx - info.start_group) * gl_WorkGroupSize.x + gl_LocalInvocationID.x;

--- a/fuzzpaint/src/ui/mod.rs
+++ b/fuzzpaint/src/ui/mod.rs
@@ -330,6 +330,8 @@ impl MainUI {
                 state::graph::LeafType::StrokeLayer {
                     blend: Blend::default(),
                     collection: new_collection,
+                    inner_transform: state::transform::Similarity::default(),
+                    outer_transform: state::transform::Matrix::default(),
                 },
             )
             .ok();
@@ -1269,6 +1271,8 @@ fn layer_buttons(
                             state::graph::LeafType::StrokeLayer {
                                 blend: Blend::default(),
                                 collection: new_stroke_collection,
+                                inner_transform: state::transform::Similarity::default(),
+                                outer_transform: state::transform::Matrix::default(),
                             },
                             addition_location,
                             "Stroke Layer".to_string(),
@@ -1295,6 +1299,7 @@ fn layer_buttons(
                             blend: Blend::default(),
                             text: "Hello, world!".to_owned(),
                             px_per_em: 50.0,
+                            outer_transform: state::transform::Matrix::default(),
                         },
                         addition_location,
                         "Text".to_string(),

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ A graphics-accelerated digital art software combining the ease-of-use of raster 
 * A modular application design allowing CLI, headless servers, and graphical clients to all share the same codebase.
 
 ### Dreams
-* Client/Server design allowing realtime peer-to-peer collaboration.
+* Optional Client/Server system allowing realtime collaboration.
 
 ### Non goals
 * Image editing - though this project aims to provide my ideal digital art creation environment over traditional raster software, it does not aim to implement the other functions of a raster image editor.
@@ -69,6 +69,7 @@ To declare **0.2.0**, I would like to be able to freely doodle a thing and save 
    - [ ] Color, Object Pickers
    - [ ] Select strokes
      - [ ] Select parts of strokes
-   - [ ] Transform existing layers and strokes
+   - [X] Transform layers
+   - [ ] Transform strokes
    - [ ] Cut, Copy, Paste strokes (within program only)
 


### PR DESCRIPTION
Basic tools for transforming stroke layers (currently the only layer type where transformation is meaningful!)

* "Inner" Similarity transforms
   * Modify the interpretation of the stylus stream during tessellation.
   * Behaves as if you drew the strokes in a different shape while keeping the brush size/spacing constant. Good for rotation/flip/translate and small size changes, but since the brush radius is constant while distances change, gaps and overlaps can occur between strokes with larger scale changes.
* "Outer" Matrix transforms.
   * Modify the interpretation of the tessellated output.
   * Visually more similar to more traditional transform tools when used in scales.
   * Although any well-formed matrix is allowed here, currently UI only exists for uniform scale and two-axis skew.
* Modifies Brush and eraser tools to work with these, ensuring that drawings correctly appear under the pen and with the correct width under any transform.

Work to do:
Live previews (longg off, probably after the planned Command Queue rework), on-document Gizmos, more Outer transform features.