### PR TITLE
Fix missing unstable feature, missing viewport initializer

### DIFF
--- a/fuzzpaint/src/main.rs
+++ b/fuzzpaint/src/main.rs
@@ -2,6 +2,7 @@
 #![feature(portable_simd)]
 #![feature(once_cell_try)]
 #![feature(write_all_vectored)]
+#![feature(new_zeroed_alloc)]
 #![feature(new_uninit)]
 #![feature(float_next_up_down)]
 #![warn(clippy::pedantic)]

--- a/fuzzpaint/src/main.rs
+++ b/fuzzpaint/src/main.rs
@@ -3,8 +3,6 @@
 #![feature(once_cell_try)]
 #![feature(write_all_vectored)]
 #![feature(new_zeroed_alloc)]
-#![feature(new_uninit)]
-#![feature(float_next_up_down)]
 #![warn(clippy::pedantic)]
 // I know it's bad but while working on a focus it's not really something I wanna be bugged about
 // with a full screen of yellow lol.

--- a/fuzzpaint/src/renderer/mod.rs
+++ b/fuzzpaint/src/renderer/mod.rs
@@ -1534,6 +1534,12 @@ mod stroke_renderer {
                         ..Default::default()
                     })?
                     .bind_pipeline_graphics(self.pipeline.clone())?
+                    .set_viewport(0, [
+                        vk::Viewport {
+                            extent: [crate::DOCUMENT_DIMENSION as f32; 2],
+                            ..Default::default()
+                        }].into_iter().collect()
+                    )?
                     .push_constants(
                         self.pipeline.layout().clone(),
                         0,


### PR DESCRIPTION
Closes #51.
A pair of silly oversights. Thank you for the reports!

The lack of the needed call to `set_viewport` was caused by #50's half-implemented changes to document sizing, wherein the pipeline was changed to expect a dynamic size in preparation for that but the dynamic size was never written.